### PR TITLE
goenv.shとgoupdate.shの環境変数の設定の修正

### DIFF
--- a/goenv.sh
+++ b/goenv.sh
@@ -4,6 +4,6 @@ sudo apt install -y golang-go
 
 git clone https://github.com/syndbg/goenv.git ~/.goenv
 
-echo "export GOENV_ROOT=$HOME/.goenv" >> ~/.bashrc
-echo "export PATH=$GOENV_ROOT/bin:$PATH" >> ~/.bashrc
-echo "eval \"$(goenv init -)\"" >> ~/.bashrc
+echo 'export GOENV_ROOT=$HOME/.goenv' >> ~/.bashrc
+echo 'export PATH=$GOENV_ROOT/bin:$PATH' >> ~/.bashrc
+echo 'eval "$(goenv init -)"' >> ~/.bashrc

--- a/goupdate.sh
+++ b/goupdate.sh
@@ -4,5 +4,5 @@ goenv install 1.11.4
 goenv global 1.11.4
 goenv rehash
 
-echo "export GOPATH=$HOME/go" >> ~/.bashrc
-echo "PATH=$PATH:$GOPATH/bin" >> ~/.bashrc
+echo 'export GOPATH=$HOME/go' >> ~/.bashrc
+echo 'PATH=$PATH:$GOPATH/bin' >> ~/.bashrc


### PR DESCRIPTION
## 変更

echoの`"`を`'`に変更した

## 内容

環境変数が展開され，$(goenv init -)が空になった．

変更前
```bash
$echo "eval \"$(goenv init -)\"" >> ~/.bashrc
```

変更後
```bash
$echo 'eval "$(goenv init -)"' >> ~/.bashrc
```